### PR TITLE
Video reconnection and Account Username Fix

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -43,7 +43,7 @@ function App() {
     townController?.disconnect();
   }, [townController]);
 
-  const handleLogin = async (e: React.FormEvent) => {
+ const handleLogin = async (e: React.FormEvent) => {
   e.preventDefault();
   
   if (!username || !password) {
@@ -57,7 +57,7 @@ function App() {
   }
 
   try {
-    const response = await fetch(`${process.env.NEXT_PUBLIC_TOWNS_SERVICE_URL}/auth/login`, {
+    const response = await fetch('http://localhost:8081/auth/login', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -68,17 +68,21 @@ function App() {
       }),
     });
 
-    const data = await response.json();
-
     if (!response.ok) {
-      throw new Error(data.message || 'Login failed');
+      const errorText = await response.text();
+      throw new Error(errorText || 'Login failed');
     }
-    console.log('Login successful, setting accountUsername to:', data.accountUsername);
 
-    // Store the account username for later use
-    setAccountUsername(data.accountUsername);
+    const data = await response.json();
+    console.log('Full login response:', data); 
+    
+    // Use fallback in case accountUsername is missing
+    const accountUsernameValue = data.accountUsername || data.name || username;
+    console.log('App.tsx - Setting accountUsername to:', accountUsernameValue); 
+    
+    setAccountUsername(accountUsernameValue);
     setIsAuthenticated(true);
-    localStorage.setItem('accountUsername', data.accountUsername);
+    localStorage.setItem('accountUsername', accountUsernameValue);
     
     toast({
       title: 'Success',
@@ -87,6 +91,7 @@ function App() {
       duration: 2000,
     });
   } catch (error) {
+    console.error('Login error:', error);
     toast({
       title: 'Login Failed',
       description: error instanceof Error ? error.message : 'Invalid credentials',
@@ -364,7 +369,7 @@ function App() {
   const townsService = new TownsServiceClient({ BASE: url }).towns;
   
   return (
-    <LoginControllerContext.Provider value={{ setTownController, townsService, accountUsername }}>
+    <LoginControllerContext.Provider value={{ setTownController, townsService, accountUsername: accountUsername || '' }}>
       <UnsupportedBrowserWarning>
         <VideoProvider options={connectionOptions} onError={setError} onDisconnect={onDisconnect}>
           <ErrorDialog dismissError={() => setError(null)} error={error} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -57,7 +57,7 @@ function App() {
   }
 
   try {
-    const response = await fetch('http://localhost:8081/auth/login', {
+      const response = await fetch(`${process.env.NEXT_PUBLIC_TOWNS_SERVICE_URL}/auth/login`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/classes/TownController.ts
+++ b/frontend/src/classes/TownController.ts
@@ -51,6 +51,7 @@ export type ConnectionProperties = {
   userName: string;
   townID: string;
   loginController: LoginController;
+  accountUsername: string; 
   spawnLocation?: PlayerLocation;
 };
 
@@ -58,6 +59,8 @@ export type ConnectionProperties = {
  * The TownController emits these events. Components may subscribe to these events
  * by calling the `addListener` method on a TownController
  */
+
+
 export type TownEvents = {
   /**
    * An event that indicates that the TownController is now connected to the townService
@@ -247,10 +250,11 @@ export default class TownController extends (EventEmitter as new () => TypedEmit
    */
   private _interactableEmitter = new EventEmitter();
 
-  public constructor({ userName, townID, loginController, spawnLocation }: ConnectionProperties) {
+  public constructor({ userName, townID, loginController, accountUsername, spawnLocation }: ConnectionProperties) {
     super();
     this._townID = townID;
     this._userName = userName;
+    this._accountUsername = accountUsername;
     this._loginController = loginController;
 
     /*
@@ -262,7 +266,7 @@ export default class TownController extends (EventEmitter as new () => TypedEmit
 
     const url = 'http://localhost:8081';
     assert(url);
-    this._socket = io(url, { auth: { userName, townID, spawnLocation } });
+    this._socket = io(url, { auth: { userName, townID, accountUsername, spawnLocation } });
     this._townsService = new TownsServiceClient({ BASE: url });
       this.registerSocketListeners();  
   }

--- a/frontend/src/components/Login/TownSelection.tsx
+++ b/frontend/src/components/Login/TownSelection.tsx
@@ -67,6 +67,12 @@ export default function TownSelection(): JSX.Element {
     };
   }, [updateTownListings]);
 
+    useEffect(() => {
+      if (!userName && accountUsername) {
+        setUserName(accountUsername);
+      }
+    }, [accountUsername, userName]);
+
   const handleJoin = useCallback(
     async (coveyRoomID: string) => {
       let connectWatchdog: NodeJS.Timeout | undefined = undefined;
@@ -263,11 +269,14 @@ export default function TownSelection(): JSX.Element {
             <FormControl>
               <FormLabel htmlFor='name'>Name</FormLabel>
               <Input
-                autoFocus
-                name='name'
-                placeholder='Your name'
-                value={userName}
-                onChange={event => setUserName(event.target.value)}
+               autoFocus
+  name='name'
+  placeholder='Your name'
+  value={userName}
+  onChange={event => setUserName(event.target.value)}
+  isReadOnly={!!accountUsername}  // Add this line - makes it read-only if accountUsername exists
+  bg={accountUsername ? 'gray.100' : 'white'}  // Add this line - grays out background when read-only
+  cursor={accountUsername ? 'not-allowed' : 'text'}  // Add this line - shows not-allowed cursor
               />
             </FormControl>
           </Box>

--- a/frontend/src/components/Login/TownSelection.tsx
+++ b/frontend/src/components/Login/TownSelection.tsx
@@ -270,13 +270,13 @@ export default function TownSelection(): JSX.Element {
               <FormLabel htmlFor='name'>Name</FormLabel>
               <Input
                autoFocus
-  name='name'
-  placeholder='Your name'
-  value={userName}
-  onChange={event => setUserName(event.target.value)}
-  isReadOnly={!!accountUsername}  // Add this line - makes it read-only if accountUsername exists
-  bg={accountUsername ? 'gray.100' : 'white'}  // Add this line - grays out background when read-only
-  cursor={accountUsername ? 'not-allowed' : 'text'}  // Add this line - shows not-allowed cursor
+                name='name'
+                placeholder='Your name'
+                value={userName}
+                onChange={event => setUserName(event.target.value)}
+                isReadOnly={!!accountUsername}  
+                bg={accountUsername ? 'gray.100' : 'white'}  
+                cursor={accountUsername ? 'not-allowed' : 'text'} 
               />
             </FormControl>
           </Box>

--- a/frontend/src/components/SocialSidebar/Profile.tsx
+++ b/frontend/src/components/SocialSidebar/Profile.tsx
@@ -472,6 +472,7 @@ useEffect(() => {
           userName: username,
           townID: townID,
           loginController,
+          accountUsername: loginController.accountUsername,
           spawnLocation,
         });
         


### PR DESCRIPTION
Updated Video Reconnection Fix that reintroduces account usernames. This was removed, which caused issues when loading friend lists. Account usernames now match the display name in Covey Town one-to-one. This display name cannot be changed.
<img width="665" height="829" alt="image" src="https://github.com/user-attachments/assets/dc15242c-07c2-4d20-814f-e62c40f3c3c2" />

<img width="665" height="559" alt="image" src="https://github.com/user-attachments/assets/290e7724-1694-4f95-8ff0-fcd6f4523409" />
